### PR TITLE
Add CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,20 @@
+#! /usr/bin/env node
+const usage = `
+Usage:
+	path-exists [--not] <path>
+
+Options:
+	-n --not         Negates the existence of the path.
+	-h --help        Show this screen.
+	-v --version     Show version.
+`;
+
+const options = require('docopt').docopt(usage, {
+	version: require('./package').version
+});
+
+const fn = require('./');
+fn(options['<path>']).then(function (exists) {
+	exists = options['--not'] ? !exists : exists;
+	process.exit(exists ? 0 : 1);
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "scripts": {
     "test": "xo && ava"
   },
+  "bin": {
+    "path-exists": "./cli.js"
+  },
   "files": [
     "index.js"
   ],
@@ -31,6 +34,7 @@
     "stat"
   ],
   "dependencies": {
+    "docopt": "^0.6.2",
     "pinkie-promise": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
```
Usage: path-exists [--not] <path>
```

---

This came out of the necessity of having to check whether a path exists from the command-line in a cross platform way while fixing https://github.com/gtramontina/ghooks/pull/64.
