### PR TITLE
security: analyze dependencies for malicious behavior

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@v1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
 
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: CI
 on:
   - push
   - pull_request
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }}
@@ -12,6 +15,11 @@ jobs:
         node-version:
           - 16
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
This PR 
1. Adds [harden-runner](https://github.com/step-security/harden-runner) GitHub Action to the workflow.
2. Sets the token permission for the workflow to `contents: read`. This is a security best practice and gets you are higher [Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) score. Your package currently has score of [4.5 out of 10](https://deps.dev/npm/path-exists). You can use https://app.stepsecurity.io to automate some of the fixes, such as adding token permissions and pinning actions to commit SHA...

[harden-runner](https://github.com/step-security/harden-runner) GitHub Action detects hijacked dependencies and compromised build tools. It correlates outbound traffic with each step of the workflow so you can see what processes are calling what endpoints. This is the analysis when run on a fork: https://app.stepsecurity.io/github/varunsh-coder/path-exists/actions/runs/1928611682

You can restrict traffic to the allowed endpoints for future runs which will block calls that compromised dependencies typically make, and an annotation will be shown in such cases. You do not need to grant any permission or install any App to use this, and the action (and agent the action uses) are open source. 

Information on how harden-runner could have detected past package hijacks can be found here: https://github.com/step-security/supply-chain-goat. Do share feedback to improve the [harden-runner](https://github.com/step-security/harden-runner) GitHub Action developer experience. Thanks!